### PR TITLE
Updated to use dependency injection (services registered in program.c…

### DIFF
--- a/Popcorn_Pals/Popcorn_Pals/Configs/UrlConfig.cs
+++ b/Popcorn_Pals/Popcorn_Pals/Configs/UrlConfig.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Popcorn_Pals.Configs
+{
+    public class UrlConfig
+    {
+        public string RapidApi { get; set; }
+    }
+}

--- a/Popcorn_Pals/Popcorn_Pals/Controllers/PopcornController.cs
+++ b/Popcorn_Pals/Popcorn_Pals/Controllers/PopcornController.cs
@@ -1,6 +1,7 @@
 using Flurl.Http;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Popcorn_Pals.Configs;
 using Popcorn_Pals.Models;
 using System.Drawing.Text;
 using System.Text;
@@ -17,15 +18,22 @@ namespace Popcorn_Pals.Controllers
     string anhKey2 = "b2f985562amsh9ea369258704508p17e603jsnc19236cf310d";
     string lisaKey = "15728bb747mshb12d9318d06a090p16bcc7jsnf46cf1933827";
     string ninaKey = "c3c31804a0msh549c51f669d98abp177bbcjsn8d40f5869cfb";
+    string steveKey = "90c699cf65mshec3ae4f525bb8c4p1cd9dbjsnd287dbed514c";
+    private readonly UrlConfig _config;
+
+    public PopcornController(UrlConfig config)
+    {
+      _config = config;
+    }
 
     [HttpGet("search")]
     public List<Search> SearchByTitle(string title, string type)
     {
-      string apiUri = $"https://streamlinewatch-streaming-guide.p.rapidapi.com/search?type={type}&query={title}";
+      string apiUri = $"{_config.RapidApi}/search?type={type}&query={title}";
       var apiTask = apiUri.WithHeaders(new
       {
         x_rapidapi_host = "streamlinewatch-streaming-guide.p.rapidapi.com",
-        x_rapidapi_key = ninaKey
+        x_rapidapi_key = steveKey
 
       }).GetJsonAsync<List<Search>>();
       apiTask.Wait();
@@ -40,11 +48,11 @@ namespace Popcorn_Pals.Controllers
     [HttpGet("movie")]
     public List<Movie> GetMovieById(int _id)
     {
-      string apiUri = $"https://streamlinewatch-streaming-guide.p.rapidapi.com/movies/{_id}?platform=web";
+      string apiUri = $"{_config.RapidApi}/movies/{_id}?platform=web";
       var apiTask = apiUri.WithHeaders(new
       {
         x_rapidapi_host = "streamlinewatch-streaming-guide.p.rapidapi.com",
-        x_rapidapi_key = ninaKey
+        x_rapidapi_key = steveKey
 
       }).GetJsonAsync<List<Movie>>();
       apiTask.Wait();
@@ -55,12 +63,12 @@ namespace Popcorn_Pals.Controllers
     [HttpGet("show")]
     public List<Show> GetShowById(int _id)
     {
-      string apiUri = $"https://streamlinewatch-streaming-guide.p.rapidapi.com/shows/{_id}?platform=web";
+      string apiUri = $"{_config.RapidApi}/shows/{_id}?platform=web";
       var apiTask = apiUri.WithHeaders(new
       {
         x_rapidapi_host = "streamlinewatch-streaming-guide.p.rapidapi.com",
 
-        x_rapidapi_key = ninaKey
+        x_rapidapi_key = steveKey
 
       }).GetJsonAsync<List<Show>>();
       apiTask.Wait();

--- a/Popcorn_Pals/Popcorn_Pals/Controllers/PopcornUserController.cs
+++ b/Popcorn_Pals/Popcorn_Pals/Controllers/PopcornUserController.cs
@@ -3,6 +3,8 @@ using Microsoft.AspNetCore.Mvc;
 using Popcorn_Pals.Models;
 using Popcorn_Pals.DAL;
 using System;
+using Popcorn_Pals.Services.Interfaces;
+using Popcorn_Pals.DAL.Interfaces;
 
 namespace Popcorn_Pals.Controllers
 {
@@ -10,25 +12,32 @@ namespace Popcorn_Pals.Controllers
   [ApiController]
   public class PopcornUserController : ControllerBase
   {
-    PopcornRepository _popRepo = new PopcornRepository();
+    private readonly IPopcornService _popcornService;
+    private readonly IPopcornRepository _popcornRepository;
+
+    public PopcornUserController(IPopcornService popcornService, IPopcornRepository popcornRepository)
+    {
+      _popcornService = popcornService;
+      _popcornRepository = popcornRepository;
+    }
 
   // User Endpoints
     [HttpPost("CreateUser")]
     public User CreateUser(string userName, string password)
     {
-      return _popRepo.AddUser(userName, password);
+      return _popcornRepository.AddUser(userName, password);
     }
 
     [HttpGet]
     public List<User> Get()
     {
-      return _popRepo.GetUsers();
+      return _popcornRepository.GetUsers();
     }
 
     [HttpGet("Login")]
     public User Login(string userName, string password)
     {
-      User user = _popRepo.GetUser(userName);
+      User user = _popcornRepository.GetUser(userName);
       if (user == null || user.Password != password)
       {
         return null;
@@ -43,31 +52,31 @@ namespace Popcorn_Pals.Controllers
     [HttpPost("AddMovieReview")]
     public UserReview AddMovieReview(int userId, int mediaId, string review, int rating)
     {
-      return _popRepo.AddMovieReview(userId, mediaId, review, rating);
+      return _popcornService.AddMovieReview(userId, mediaId, review, rating);
     }
 
     [HttpPost("AddShowReview")]
     public UserReview AddShowReview(int userId, int mediaId, string review, int rating)
     {
-      return _popRepo.AddShowReview(userId, mediaId, review, rating);
+      return _popcornService.AddShowReview(userId, mediaId, review, rating);
     }
 
     [HttpPost("GetReviewByMediaId")]
     public List<UserReview> GetReviewByMediaId(int mediaId)
     {
-      return _popRepo.GetReviewByMediaId(mediaId);
+      return _popcornRepository.GetReviewByMediaId(mediaId);
     }
 
     [HttpPost("GetReviewByUserId")]
     public List<UserReview> GetReviewByUserId(int userId)
     {
-      return _popRepo.GetReviewByUserId(userId);
+      return _popcornRepository.GetReviewByUserId(userId);
     }
 
     [HttpPost("GetReviewByReviewId")]
     public List<UserReview> GetReviewByReviewId(int reviewId)
     {
-      return _popRepo.GetReviewByReviewId(reviewId);
+      return _popcornRepository.GetReviewByReviewId(reviewId);
     }
 
     // ADD EDIT REVIEW
@@ -78,19 +87,19 @@ namespace Popcorn_Pals.Controllers
     [HttpPost("FollowUser")]
     public Follow FollowUser(int userId, int userToFollow)
     {
-      return _popRepo.FollowUser(userId, userToFollow);
+      return _popcornRepository.FollowUser(userId, userToFollow);
     }
 
     [HttpPost("GetFollowers")]
     public List<Follow> GetFollowers(int userId)
     {
-      return _popRepo.GetFollowers(userId);
+      return _popcornRepository.GetFollowers(userId);
     }
 
     [HttpPost("GetFollowing")]
     public List<Follow> GetFollowing(int userId)
     {
-      return _popRepo.GetFollowing(userId);
+      return _popcornRepository.GetFollowing(userId);
     }
 
   }

--- a/Popcorn_Pals/Popcorn_Pals/DAL/Interfaces/IPopcornRepository.cs
+++ b/Popcorn_Pals/Popcorn_Pals/DAL/Interfaces/IPopcornRepository.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Popcorn_Pals.Models;
+
+namespace Popcorn_Pals.DAL.Interfaces
+{
+  public interface IPopcornRepository
+  {
+    public List<User> GetUsers();
+
+    User GetUser(string userName);
+
+    User AddUser(string userName, string password);
+    User GetUserById(int id);
+
+
+
+    // Review Methods //
+    UserReview AddMovieReview(UserReview reviewToAdd);
+
+    UserReview AddShowReview(UserReview reviewToAdd);
+
+    List<UserReview> GetReviewByMediaId(int mediaId);
+
+    List<UserReview> GetReviewByUserId(int userId);
+
+    List<UserReview> GetReviewByReviewId(int id);
+
+
+
+    // Follow Methods //
+    Follow FollowUser(int user, int userToFollow);
+
+    List<Follow> GetFollowers(int userId);
+
+    List<Follow> GetFollowing(int userId);
+  }
+}

--- a/Popcorn_Pals/Popcorn_Pals/DAL/PopcornContext.cs
+++ b/Popcorn_Pals/Popcorn_Pals/DAL/PopcornContext.cs
@@ -33,6 +33,7 @@ namespace Popcorn_Pals
 
         _configuration = builder.Build();
         string cnstr = _configuration.GetConnectionString("PopcornDb");
+        Console.WriteLine($"{cnstr}");
         optionsBuilder.UseSqlServer(cnstr);
       }
     }

--- a/Popcorn_Pals/Popcorn_Pals/DAL/PopcornRepository.cs
+++ b/Popcorn_Pals/Popcorn_Pals/DAL/PopcornRepository.cs
@@ -1,13 +1,12 @@
 using Popcorn_Pals.Models;
-using Popcorn_Pals.DAL;
+using Popcorn_Pals.DAL.Interfaces;
 using Popcorn_Pals.Controllers;
 using System;
 
 namespace Popcorn_Pals.DAL
 {
-  public class PopcornRepository
+  public class PopcornRepository : IPopcornRepository
   {
-    private PopcornController _controller = new PopcornController();
     private PopcornContext _popContext = new PopcornContext();
 
 
@@ -66,35 +65,15 @@ namespace Popcorn_Pals.DAL
 
 
 // Review Methods //
-    public UserReview AddMovieReview(int userId, int mediaId, string review, int rating)
+    public UserReview AddMovieReview(UserReview reviewToAdd)
     {
-      Movie movieToReview = _controller.GetMovieById(mediaId).FirstOrDefault(x => x._id == mediaId);
-      UserReview reviewToAdd = new UserReview()
-      {
-        UserId = userId,
-        MediaId = movieToReview._id,
-        Movie = movieToReview,
-        Review = review,
-        Rating = rating
-      };
-
       _popContext.Reviews.Add(reviewToAdd);
       _popContext.SaveChanges();
       return reviewToAdd;
     }
 
-    public UserReview AddShowReview(int userId, int mediaId, string review, int rating)
+    public UserReview AddShowReview(UserReview reviewToAdd)
     {
-      Show showToReview = _controller.GetShowById(mediaId).FirstOrDefault(x => x._id == mediaId);
-      UserReview reviewToAdd = new UserReview()
-      {
-        UserId = userId,
-        MediaId = showToReview._id,
-        Show = showToReview,
-        Review = review,
-        Rating = rating
-      };
-
       _popContext.Reviews.Add(reviewToAdd);
       _popContext.SaveChanges();
       return reviewToAdd;

--- a/Popcorn_Pals/Popcorn_Pals/Program.cs
+++ b/Popcorn_Pals/Popcorn_Pals/Program.cs
@@ -1,6 +1,24 @@
+using Popcorn_Pals.Configs;
+using Popcorn_Pals.DAL;
+using Popcorn_Pals.DAL.Interfaces;
+using Popcorn_Pals.Services;
+using Popcorn_Pals.Services.Interfaces;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
+// var configSection = builder.Configuration.GetSection("ExternalUrls");
+
+// builder.Services.Configure<UrlConfig>(configSection);
+
+var urlConfig = new UrlConfig();
+builder.Configuration.Bind("ExternalUrls", urlConfig);
+
+builder.Services.AddSingleton<UrlConfig>(urlConfig);
+
+builder.Services.AddScoped<IPopcornRepository, PopcornRepository>();
+builder.Services.AddScoped<IRapidApiService, RapidApiService>();
+builder.Services.AddScoped<IPopcornService, PopcornService>();
 
 
 builder.Services.AddControllers();

--- a/Popcorn_Pals/Popcorn_Pals/Services/Interfaces/IPopcornService.cs
+++ b/Popcorn_Pals/Popcorn_Pals/Services/Interfaces/IPopcornService.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Popcorn_Pals.Models;
+
+namespace Popcorn_Pals.Services.Interfaces
+{
+    public interface IPopcornService
+    {
+        UserReview AddShowReview(int userId, int mediaId, string review, int rating);
+        UserReview AddMovieReview(int userId, int mediaId, string review, int rating);
+    }
+}

--- a/Popcorn_Pals/Popcorn_Pals/Services/Interfaces/IRapidApiService.cs
+++ b/Popcorn_Pals/Popcorn_Pals/Services/Interfaces/IRapidApiService.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Popcorn_Pals.Models;
+
+namespace Popcorn_Pals.Services.Interfaces
+{
+    public interface IRapidApiService
+    {
+        List<Show> GetShowById(int _id);
+        List<Movie> GetMovieById(int _id);
+    }
+}

--- a/Popcorn_Pals/Popcorn_Pals/Services/PopcornService.cs
+++ b/Popcorn_Pals/Popcorn_Pals/Services/PopcornService.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Popcorn_Pals.DAL.Interfaces;
+using Popcorn_Pals.Models;
+using Popcorn_Pals.Services.Interfaces;
+
+namespace Popcorn_Pals.Services
+{
+  public class PopcornService : IPopcornService
+  {
+    private readonly IRapidApiService _rapidApiService;
+    private readonly IPopcornRepository _popcornRepository;
+
+    public PopcornService(IRapidApiService rapidApiService, IPopcornRepository popcornRepository)
+    {
+        _rapidApiService = rapidApiService;
+        _popcornRepository = popcornRepository;
+    }
+
+    public UserReview AddMovieReview(int userId, int mediaId, string review, int rating)
+    {
+      Movie movieToReview = _rapidApiService.GetMovieById(mediaId).FirstOrDefault(x => x._id == mediaId);
+      UserReview reviewToAdd = new UserReview()
+      {
+        UserId = userId,
+        MediaId = movieToReview._id,
+        Movie = movieToReview,
+        Review = review,
+        Rating = rating
+      };
+
+      
+      return _popcornRepository.AddMovieReview(reviewToAdd);
+    }
+
+    public UserReview AddShowReview(int userId, int mediaId, string review, int rating)
+    {
+      Show showToReview = _rapidApiService.GetShowById(mediaId).FirstOrDefault(x => x._id == mediaId);
+      UserReview reviewToAdd = new UserReview()
+      {
+        UserId = userId,
+        MediaId = showToReview._id,
+        Show = showToReview,
+        Review = review,
+        Rating = rating
+      };
+
+
+      _popcornRepository.AddShowReview(reviewToAdd);
+      return reviewToAdd;
+    }
+  }
+}

--- a/Popcorn_Pals/Popcorn_Pals/Services/RapidApiService.cs
+++ b/Popcorn_Pals/Popcorn_Pals/Services/RapidApiService.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Popcorn_Pals.Models;
+using Popcorn_Pals.Services.Interfaces;
+
+namespace Popcorn_Pals.Services
+{
+  public class RapidApiService : IRapidApiService
+  {
+    public List<Show> GetShowById(int _id)
+    {
+      throw new NotImplementedException();
+    }
+
+    public List<Movie> GetMovieById(int _id)
+    {
+        throw new NotImplementedException();
+    }
+  }
+}

--- a/Popcorn_Pals/Popcorn_Pals/appsettings.Development.json
+++ b/Popcorn_Pals/Popcorn_Pals/appsettings.Development.json
@@ -4,5 +4,11 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "ConnectionStrings": {
+    "PopcornDb": "Server=localhost\\SQLEXPRESS;Database=master;Trusted_Connection=True;"
+  },
+  "ExternalUrls": {
+    "RapidApi": "https://streamlinewatch-streaming-guide.p.rapidapi.com"
   }
 }


### PR DESCRIPTION
Leveraging the .net container services to register services and configurations.  This avoids ever having to call new xxxController() or new xxxRepository().

![image](https://user-images.githubusercontent.com/57924484/227807947-ec0104ed-e890-48ee-919a-e4902fa3d689.png)

Also added a service layer and interfaces.  Again this is to leverage dependency injection and code to the interface (not the implementation).  For instance, you can later change the register services to attach a different implementation to the same interface.  For example, say you change your DAL to PostgresSql and add new Repository classes that inherit IPopcornRepository, you just need to change Program.cs to attach that implementation to IPopcornRepository.

Additionally, I moved the RapidApi URL to the appsettings file and created a class to represent the "ExternalUrls" section of appsettings.  So when the application loads it reads in the settings and binds those specific settings in that section to a class.  Then you register the class as a singleton so that it is globally available.  The PopcornController is using Constructor injection to take in this instance of the config, and now the URL is not hardcoded several times throughout the file.